### PR TITLE
fix: handle edge case for empty disclosures in SdJwtVP parsing

### DIFF
--- a/src/main/java/de/adorsys/sdjwt/vp/SdJwtVP.java
+++ b/src/main/java/de/adorsys/sdjwt/vp/SdJwtVP.java
@@ -66,12 +66,6 @@ public class SdJwtVP {
         return keyBindingJWT;
     }
 
-    
-    public String getIssuerSignedJWTString() {
-        return getIssuerSignedJWT().toString();
-    }
-
-
     private SdJwtVP(String sdJwtVpString, String hashAlgorithm, IssuerSignedJWT issuerSignedJWT,
                     Map<String, ArrayNode> claims, Map<String, String> disclosures, Map<String, String> recursiveDigests,
                     List<String> ghostDigests, Optional<KeyBindingJWT> keyBindingJWT) {
@@ -90,7 +84,7 @@ public class SdJwtVP {
         int disclosureEnd = sdJwtString.lastIndexOf(SdJwt.DELIMITER);
 
         if (disclosureStart == -1) {
-            throw new IllegalArgumentException("No disclosure found");
+            throw new IllegalArgumentException("SD-JWT is malformed, expected to end with " + SdJwt.DELIMITER);
         }
 
         String issuerSignedJWTString = sdJwtString.substring(0, disclosureStart);

--- a/src/main/java/de/adorsys/sdjwt/vp/SdJwtVP.java
+++ b/src/main/java/de/adorsys/sdjwt/vp/SdJwtVP.java
@@ -66,6 +66,12 @@ public class SdJwtVP {
         return keyBindingJWT;
     }
 
+    
+    public String getIssuerSignedJWTString() {
+        return getIssuerSignedJWT().toString();
+    }
+
+
     private SdJwtVP(String sdJwtVpString, String hashAlgorithm, IssuerSignedJWT issuerSignedJWT,
                     Map<String, ArrayNode> claims, Map<String, String> disclosures, Map<String, String> recursiveDigests,
                     List<String> ghostDigests, Optional<KeyBindingJWT> keyBindingJWT) {
@@ -82,6 +88,10 @@ public class SdJwtVP {
     public static SdJwtVP of(String sdJwtString) {
         int disclosureStart = sdJwtString.indexOf(SdJwt.DELIMITER);
         int disclosureEnd = sdJwtString.lastIndexOf(SdJwt.DELIMITER);
+
+        if (disclosureStart == -1) {
+            throw new IllegalArgumentException("No disclosure found");
+        }
 
         String issuerSignedJWTString = sdJwtString.substring(0, disclosureStart);
         String disclosuresString = "";

--- a/src/main/java/de/adorsys/sdjwt/vp/SdJwtVP.java
+++ b/src/main/java/de/adorsys/sdjwt/vp/SdJwtVP.java
@@ -84,7 +84,11 @@ public class SdJwtVP {
         int disclosureEnd = sdJwtString.lastIndexOf(SdJwt.DELIMITER);
 
         String issuerSignedJWTString = sdJwtString.substring(0, disclosureStart);
-        String disclosuresString = sdJwtString.substring(disclosureStart + 1, disclosureEnd);
+        String disclosuresString = "";
+
+        if (disclosureEnd > disclosureStart) {
+            disclosuresString = sdJwtString.substring(disclosureStart + 1, disclosureEnd);
+        }
 
         IssuerSignedJWT issuerSignedJWT = IssuerSignedJWT.fromJws(issuerSignedJWTString);
 

--- a/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPTest.java
+++ b/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPTest.java
@@ -191,21 +191,21 @@ public class SdJwtVPTest {
 
     @Test
     public void testOf_validInput() {
-    String sdJwtString = TestUtils.readFileAsString(getClass(), "sdjwt/s6.2-presented-sdjwtvp.txt");
-    SdJwtVP sdJwtVP = SdJwtVP.of(sdJwtString);
+        String sdJwtString = TestUtils.readFileAsString(getClass(), "sdjwt/s6.2-presented-sdjwtvp.txt");
+        SdJwtVP sdJwtVP = SdJwtVP.of(sdJwtString);
 
-    assertNotNull(sdJwtVP);
-    assertEquals(4, sdJwtVP.getDisclosures().size());
+        assertNotNull(sdJwtVP);
+        assertEquals(4, sdJwtVP.getDisclosures().size());
     }
 
     @Test
     public void testOf_MalformedSdJwt_ThrowsIllegalArgumentException() {
-    // Given
-    String malformedSdJwt = "issuer-signed-jwt"; // missing delimiter at the end
+        // Given
+        String malformedSdJwt = "issuer-signed-jwt"; // missing delimiter at the end
 
-    // When & Then
-    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> SdJwtVP.of(malformedSdJwt));
-    assertEquals("SD-JWT is malformed, expected to end with ~", exception.getMessage());
+        // When & Then
+        var exception = assertThrows(IllegalArgumentException.class, () -> SdJwtVP.of(malformedSdJwt));
+        assertEquals("SD-JWT is malformed, expected to end with ~", exception.getMessage());
     }
 
 }

--- a/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPTest.java
+++ b/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPTest.java
@@ -16,10 +16,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+
 
 /**
  * @author <a href="mailto:francis.pouatcha@adorsys.com">Francis Pouatcha</a>
@@ -171,7 +170,7 @@ public class SdJwtVPTest {
         // Verify with wrong public key from settings (issuer)
         presenteSdJwtVP.getKeyBindingJWT().get().verifySignature(testSettings.issuerVerifierContext.verifier);
     }
-
+    
     @Test
     public void testS6_2_PresentationPartialDisclosure() throws ParseException, JOSEException {
         String jwsType = "vc+sd-jwt";
@@ -180,8 +179,7 @@ public class SdJwtVPTest {
         JsonNode keyBindingClaims = TestUtils.readClaimSet(getClass(), "sdjwt/s6.2-key-binding-claims.json");
         // disclose only the given_name
         String presentation = sdJwtVP.present(List.of("jsu9yVulwQQlhFlM_3JlzMaSFzglhQG0DpfayQwLUK4"),
-                keyBindingClaims, testSettings.holderSigContext.signer, testSettings.holderSigContext.keyId,
-                testSettings.jwsAlgorithm, jwsType);
+                keyBindingClaims, testSettings.holderSigContext.signer, testSettings.holderSigContext.keyId, testSettings.jwsAlgorithm, jwsType);
 
         SdJwtVP presenteSdJwtVP = SdJwtVP.of(presentation);
         assertTrue(presenteSdJwtVP.getKeyBindingJWT().isPresent());
@@ -201,14 +199,11 @@ public class SdJwtVPTest {
     }
 
     @Test
-    public void testOf_noDisclosure() {
-        String sdJwtString = "issuer-signed-jwt";
-        try {
-            SdJwtVP.of(sdJwtString);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertEquals("No disclosure found", e.getMessage());
-        }
+    public void testOf_MalformedSdJwt_ThrowsIllegalArgumentException() {
+        // Given
+        String malformedSdJwt = "issuer-signed-jwt"; // missing delimiter at the end
+
+        assertThrows(IllegalArgumentException.class, () -> SdJwtVP.of(malformedSdJwt));
     }
 
 }

--- a/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPTest.java
+++ b/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPTest.java
@@ -200,10 +200,12 @@ public class SdJwtVPTest {
 
     @Test
     public void testOf_MalformedSdJwt_ThrowsIllegalArgumentException() {
-        // Given
-        String malformedSdJwt = "issuer-signed-jwt"; // missing delimiter at the end
+    // Given
+    String malformedSdJwt = "issuer-signed-jwt"; // missing delimiter at the end
 
-        assertThrows(IllegalArgumentException.class, () -> SdJwtVP.of(malformedSdJwt));
+    // When & Then
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> SdJwtVP.of(malformedSdJwt));
+    assertEquals("SD-JWT is malformed, expected to end with ~", exception.getMessage());
     }
 
 }

--- a/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPTest.java
+++ b/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPTest.java
@@ -15,7 +15,11 @@ import java.text.ParseException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author <a href="mailto:francis.pouatcha@adorsys.com">Francis Pouatcha</a>
@@ -176,7 +180,8 @@ public class SdJwtVPTest {
         JsonNode keyBindingClaims = TestUtils.readClaimSet(getClass(), "sdjwt/s6.2-key-binding-claims.json");
         // disclose only the given_name
         String presentation = sdJwtVP.present(List.of("jsu9yVulwQQlhFlM_3JlzMaSFzglhQG0DpfayQwLUK4"),
-                keyBindingClaims, testSettings.holderSigContext.signer, testSettings.holderSigContext.keyId, testSettings.jwsAlgorithm, jwsType);
+                keyBindingClaims, testSettings.holderSigContext.signer, testSettings.holderSigContext.keyId,
+                testSettings.jwsAlgorithm, jwsType);
 
         SdJwtVP presenteSdJwtVP = SdJwtVP.of(presentation);
         assertTrue(presenteSdJwtVP.getKeyBindingJWT().isPresent());
@@ -184,6 +189,26 @@ public class SdJwtVPTest {
         // Verify with public key from cnf claim
         presenteSdJwtVP.getKeyBindingJWT().get()
                 .verifySignature(TestSettings.verifierContextFrom(presenteSdJwtVP.getCnfClaim(), "ES256"));
+    }
+
+    @Test
+    public void testOf_validInput() {
+    String sdJwtString = TestUtils.readFileAsString(getClass(), "sdjwt/s6.2-presented-sdjwtvp.txt");
+    SdJwtVP sdJwtVP = SdJwtVP.of(sdJwtString);
+
+    assertNotNull(sdJwtVP);
+    assertEquals(4, sdJwtVP.getDisclosures().size());
+    }
+
+    @Test
+    public void testOf_noDisclosure() {
+        String sdJwtString = "issuer-signed-jwt";
+        try {
+            SdJwtVP.of(sdJwtString);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("No disclosure found", e.getMessage());
+        }
     }
 
 }


### PR DESCRIPTION
Here are the necessary changes i made in this file,;

- I added a check to see if disclosureEnd is greater than disclosureStart. If it is, I extract the disclosures string from the original SD-JWT string using substring(disclosureStart + 1, disclosureEnd).

- If disclosureEnd is not greater than disclosureStart, I set disclosuresString to an empty string (""). This ensures that an empty value is assigned when there are no disclosures.

I'll be waiting to for your review @IngridPuppet  and any for any updates on the file.