### PR TITLE
Run time comparisons taking account of possible clock skew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: Build (and Test)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Build with Maven
+        run: ./mvnw clean package

--- a/src/main/java/de/adorsys/sdjwt/IssuerSignedJwtVerificationOpts.java
+++ b/src/main/java/de/adorsys/sdjwt/IssuerSignedJwtVerificationOpts.java
@@ -7,71 +7,32 @@ import com.nimbusds.jose.JWSVerifier;
  *
  * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
  */
-public class IssuerSignedJwtVerificationOpts {
+public class IssuerSignedJwtVerificationOpts extends TimeClaimVerificationOpts {
+
     private final JWSVerifier verifier;
-
-    private final boolean validateExpirationClaim;
-    private final boolean validateNotBeforeClaim;
-
-    /**
-     * Tolerance window to account for clock skew when checking time claims
-     */
-    private final int leewaySeconds;
 
     public IssuerSignedJwtVerificationOpts(
             JWSVerifier verifier,
             boolean validateExpirationClaim,
             boolean validateNotBeforeClaim,
             int leewaySeconds) {
+        super(validateExpirationClaim, validateNotBeforeClaim, leewaySeconds);
         this.verifier = verifier;
-        this.validateExpirationClaim = validateExpirationClaim;
-        this.validateNotBeforeClaim = validateNotBeforeClaim;
-        this.leewaySeconds = leewaySeconds;
     }
 
     public JWSVerifier getVerifier() {
         return verifier;
     }
 
-    public boolean mustValidateExpirationClaim() {
-        return validateExpirationClaim;
+    public static Builder builder() {
+        return new Builder();
     }
 
-    public boolean mustValidateNotBeforeClaim() {
-        return validateNotBeforeClaim;
-    }
-
-    public int getLeewaySeconds() {
-        return leewaySeconds;
-    }
-
-    public static IssuerSignedJwtVerificationOpts.Builder builder() {
-        return new IssuerSignedJwtVerificationOpts.Builder();
-    }
-
-    public static class Builder {
+    public static class Builder extends TimeClaimVerificationOpts.Builder<Builder> {
         private JWSVerifier verifier;
-        private boolean validateExpirationClaim = true;
-        private boolean validateNotBeforeClaim = true;
-        private int leewaySeconds = 10;
 
         public Builder withVerifier(JWSVerifier verifier) {
             this.verifier = verifier;
-            return this;
-        }
-
-        public Builder withValidateExpirationClaim(boolean validateExpirationClaim) {
-            this.validateExpirationClaim = validateExpirationClaim;
-            return this;
-        }
-
-        public Builder withValidateNotBeforeClaim(boolean validateNotBeforeClaim) {
-            this.validateNotBeforeClaim = validateNotBeforeClaim;
-            return this;
-        }
-
-        public Builder withLeewaySeconds(int leewaySeconds) {
-            this.leewaySeconds = leewaySeconds;
             return this;
         }
 

--- a/src/main/java/de/adorsys/sdjwt/IssuerSignedJwtVerificationOpts.java
+++ b/src/main/java/de/adorsys/sdjwt/IssuerSignedJwtVerificationOpts.java
@@ -9,27 +9,28 @@ import com.nimbusds.jose.JWSVerifier;
  */
 public class IssuerSignedJwtVerificationOpts {
     private final JWSVerifier verifier;
-    private final boolean validateIssuedAtClaim;
+
     private final boolean validateExpirationClaim;
     private final boolean validateNotBeforeClaim;
 
+    /**
+     * Tolerance window to account for clock skew when checking time claims
+     */
+    private final int leewaySeconds;
+
     public IssuerSignedJwtVerificationOpts(
             JWSVerifier verifier,
-            boolean validateIssuedAtClaim,
             boolean validateExpirationClaim,
-            boolean validateNotBeforeClaim) {
+            boolean validateNotBeforeClaim,
+            int leewaySeconds) {
         this.verifier = verifier;
-        this.validateIssuedAtClaim = validateIssuedAtClaim;
         this.validateExpirationClaim = validateExpirationClaim;
         this.validateNotBeforeClaim = validateNotBeforeClaim;
+        this.leewaySeconds = leewaySeconds;
     }
 
     public JWSVerifier getVerifier() {
         return verifier;
-    }
-
-    public boolean mustValidateIssuedAtClaim() {
-        return validateIssuedAtClaim;
     }
 
     public boolean mustValidateExpirationClaim() {
@@ -40,23 +41,22 @@ public class IssuerSignedJwtVerificationOpts {
         return validateNotBeforeClaim;
     }
 
+    public int getLeewaySeconds() {
+        return leewaySeconds;
+    }
+
     public static IssuerSignedJwtVerificationOpts.Builder builder() {
         return new IssuerSignedJwtVerificationOpts.Builder();
     }
 
     public static class Builder {
         private JWSVerifier verifier;
-        private boolean validateIssuedAtClaim;
         private boolean validateExpirationClaim = true;
         private boolean validateNotBeforeClaim = true;
+        private int leewaySeconds = 10;
 
         public Builder withVerifier(JWSVerifier verifier) {
             this.verifier = verifier;
-            return this;
-        }
-
-        public Builder withValidateIssuedAtClaim(boolean validateIssuedAtClaim) {
-            this.validateIssuedAtClaim = validateIssuedAtClaim;
             return this;
         }
 
@@ -70,12 +70,17 @@ public class IssuerSignedJwtVerificationOpts {
             return this;
         }
 
+        public Builder withLeewaySeconds(int leewaySeconds) {
+            this.leewaySeconds = leewaySeconds;
+            return this;
+        }
+
         public IssuerSignedJwtVerificationOpts build() {
             return new IssuerSignedJwtVerificationOpts(
                     verifier,
-                    validateIssuedAtClaim,
                     validateExpirationClaim,
-                    validateNotBeforeClaim
+                    validateNotBeforeClaim,
+                    leewaySeconds
             );
         }
     }

--- a/src/main/java/de/adorsys/sdjwt/SdJws.java
+++ b/src/main/java/de/adorsys/sdjwt/SdJws.java
@@ -8,7 +8,6 @@ import com.nimbusds.jose.util.Base64URL;
 
 import java.io.IOException;
 import java.text.ParseException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -94,30 +93,6 @@ public abstract class SdJws {
     public void verifySignature(JWSVerifier verifier) throws JOSEException {
         if (!this.signedJwt.verify(verifier)) {
             throw new JOSEException("Invalid JWS signature");
-        }
-    }
-
-    public void verifyIssuedAtClaim() throws SdJwtVerificationException {
-        // The purpose of this method was to check if `iat` is not in the future.
-        // However, this cannot be achieved at high resolution between times provided
-        // by different systems. So we removed our unreliable implementation.
-    }
-
-    public void verifyExpClaim() throws SdJwtVerificationException {
-        long now = Instant.now().getEpochSecond();
-        long exp = SdJwtUtils.readTimeClaim(payload, "exp");
-
-        if (now >= exp) {
-            throw new SdJwtVerificationException("jwt has expired");
-        }
-    }
-
-    public void verifyNotBeforeClaim() throws SdJwtVerificationException {
-        long now = Instant.now().getEpochSecond();
-        long nbf = SdJwtUtils.readTimeClaim(payload, "nbf");
-
-        if (now < nbf) {
-            throw new SdJwtVerificationException("jwt not valid yet");
         }
     }
 

--- a/src/main/java/de/adorsys/sdjwt/SdJwtUtils.java
+++ b/src/main/java/de/adorsys/sdjwt/SdJwtUtils.java
@@ -16,6 +16,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -96,6 +97,8 @@ public class SdJwtUtils {
     }
 
     public static long readTimeClaim(JsonNode payload, String claimName) throws SdJwtVerificationException {
+        Objects.requireNonNull(payload);
+
         JsonNode claim = payload.get(claimName);
         if (claim == null || !claim.isNumber()) {
             throw new SdJwtVerificationException("Missing or invalid '" + claimName + "' claim");

--- a/src/main/java/de/adorsys/sdjwt/SdJwtVerificationContext.java
+++ b/src/main/java/de/adorsys/sdjwt/SdJwtVerificationContext.java
@@ -1,8 +1,5 @@
 package de.adorsys.sdjwt;
 
-import de.adorsys.sdjwt.exception.SdJwtVerificationException;
-import de.adorsys.sdjwt.vp.KeyBindingJWT;
-import de.adorsys.sdjwt.vp.KeyBindingJwtVerificationOpts;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -13,9 +10,11 @@ import com.nimbusds.jose.crypto.Ed25519Verifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyType;
+import de.adorsys.sdjwt.exception.SdJwtVerificationException;
+import de.adorsys.sdjwt.vp.KeyBindingJWT;
+import de.adorsys.sdjwt.vp.KeyBindingJwtVerificationOpts;
 
 import java.text.ParseException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -258,36 +257,31 @@ public class SdJwtVerificationContext {
      * If a required validity-controlling claim is missing, the SD-JWT MUST be rejected.
      * </p>
      *
+     * <p>
+     * Issuers will typically include claims controlling the validity of the SD-JWT in plaintext in the
+     * SD-JWT payload, but there is no guarantee they would do so. Therefore, Verifiers cannot reliably
+     * depend on that and need to operate as though security-critical claims might be selectively disclosable.
+     * </p>
+     *
      * @throws SdJwtVerificationException if verification failed
      */
     private void validateIssuerSignedJwtTimeClaims(
             JsonNode payload,
             IssuerSignedJwtVerificationOpts issuerSignedJwtVerificationOpts
     ) throws SdJwtVerificationException {
-        long now = Instant.now().getEpochSecond();
+        var timeClaimVerifier = new TimeClaimVerifier(issuerSignedJwtVerificationOpts.getLeewaySeconds());
 
         try {
-            if (issuerSignedJwtVerificationOpts.mustValidateIssuedAtClaim()
-                    && now < SdJwtUtils.readTimeClaim(payload, "iat")) {
-                throw new SdJwtVerificationException("JWT issued in the future");
-            }
-        } catch (SdJwtVerificationException e) {
-            throw new SdJwtVerificationException("Issuer-Signed JWT: Invalid `iat` claim", e);
-        }
-
-        try {
-            if (issuerSignedJwtVerificationOpts.mustValidateExpirationClaim()
-                    && now >= SdJwtUtils.readTimeClaim(payload, "exp")) {
-                throw new SdJwtVerificationException("JWT has expired");
+            if (issuerSignedJwtVerificationOpts.mustValidateExpirationClaim()) {
+                timeClaimVerifier.verifyExpClaim(payload);
             }
         } catch (SdJwtVerificationException e) {
             throw new SdJwtVerificationException("Issuer-Signed JWT: Invalid `exp` claim", e);
         }
 
         try {
-            if (issuerSignedJwtVerificationOpts.mustValidateNotBeforeClaim()
-                    && now < SdJwtUtils.readTimeClaim(payload, "nbf")) {
-                throw new SdJwtVerificationException("JWT is not yet valid");
+            if (issuerSignedJwtVerificationOpts.mustValidateNotBeforeClaim()) {
+                timeClaimVerifier.verifyNotBeforeClaim(payload);
             }
         } catch (SdJwtVerificationException e) {
             throw new SdJwtVerificationException("Issuer-Signed JWT: Invalid `nbf` claim", e);
@@ -302,16 +296,12 @@ public class SdJwtVerificationContext {
     private void validateKeyBindingJwtTimeClaims(
             KeyBindingJwtVerificationOpts keyBindingJwtVerificationOpts
     ) throws SdJwtVerificationException {
+        var timeClaimVerifier = new TimeClaimVerifier(keyBindingJwtVerificationOpts.getLeewaySeconds());
+
         // Check that the creation time of the Key Binding JWT, as determined by the iat claim,
         // is within an acceptable window
 
-        try {
-            keyBindingJwt.verifyIssuedAtClaim();
-        } catch (SdJwtVerificationException e) {
-            throw new SdJwtVerificationException("Key binding JWT: Invalid `iat` claim", e);
-        }
-
-        long now = Instant.now().getEpochSecond();
+        long now = timeClaimVerifier.currentTimestamp();
         long keyBindingJwtIat = SdJwtUtils.readTimeClaim(keyBindingJwt.getPayload(), "iat");
 
         if (now - keyBindingJwtIat > keyBindingJwtVerificationOpts.getAllowedMaxAge()) {
@@ -322,7 +312,7 @@ public class SdJwtVerificationContext {
 
         try {
             if (keyBindingJwtVerificationOpts.mustValidateExpirationClaim()) {
-                keyBindingJwt.verifyExpClaim();
+                timeClaimVerifier.verifyExpClaim(keyBindingJwt.getPayload());
             }
         } catch (SdJwtVerificationException e) {
             throw new SdJwtVerificationException("Key binding JWT: Invalid `exp` claim", e);
@@ -330,7 +320,7 @@ public class SdJwtVerificationContext {
 
         try {
             if (keyBindingJwtVerificationOpts.mustValidateNotBeforeClaim()) {
-                keyBindingJwt.verifyNotBeforeClaim();
+                timeClaimVerifier.verifyNotBeforeClaim(keyBindingJwt.getPayload());
             }
         } catch (SdJwtVerificationException e) {
             throw new SdJwtVerificationException("Key binding JWT: Invalid `nbf` claim", e);

--- a/src/main/java/de/adorsys/sdjwt/TimeClaimVerificationOpts.java
+++ b/src/main/java/de/adorsys/sdjwt/TimeClaimVerificationOpts.java
@@ -1,0 +1,76 @@
+package de.adorsys.sdjwt;
+
+/**
+ * Options for validating common time claims during SD-JWT verification.
+ *
+ * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
+ */
+public class TimeClaimVerificationOpts {
+
+    /**
+     * Tolerance window to account for clock skew when checking time claims
+     */
+    public static final int DEFAULT_LEEWAY_SECONDS = 10;
+
+    private final boolean validateExpirationClaim;
+    private final boolean validateNotBeforeClaim;
+    private final int leewaySeconds;
+
+    public TimeClaimVerificationOpts(
+            boolean validateExpirationClaim,
+            boolean validateNotBeforeClaim,
+            int leewaySeconds) {
+        this.validateExpirationClaim = validateExpirationClaim;
+        this.validateNotBeforeClaim = validateNotBeforeClaim;
+        this.leewaySeconds = leewaySeconds;
+    }
+
+    public boolean mustValidateExpirationClaim() {
+        return validateExpirationClaim;
+    }
+
+    public boolean mustValidateNotBeforeClaim() {
+        return validateNotBeforeClaim;
+    }
+
+    public int getLeewaySeconds() {
+        return leewaySeconds;
+    }
+
+    public static <T extends Builder<T>> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<T>> {
+
+        protected boolean validateExpirationClaim = true;
+        protected boolean validateNotBeforeClaim = true;
+        protected int leewaySeconds = DEFAULT_LEEWAY_SECONDS;
+
+        @SuppressWarnings("unchecked")
+        public T withValidateExpirationClaim(boolean validateExpirationClaim) {
+            this.validateExpirationClaim = validateExpirationClaim;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withValidateNotBeforeClaim(boolean validateNotBeforeClaim) {
+            this.validateNotBeforeClaim = validateNotBeforeClaim;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withLeewaySeconds(int leewaySeconds) {
+            this.leewaySeconds = leewaySeconds;
+            return (T) this;
+        }
+
+        public TimeClaimVerificationOpts build() {
+            return new TimeClaimVerificationOpts(
+                    validateExpirationClaim,
+                    validateNotBeforeClaim,
+                    leewaySeconds
+            );
+        }
+    }
+}

--- a/src/main/java/de/adorsys/sdjwt/TimeClaimVerifier.java
+++ b/src/main/java/de/adorsys/sdjwt/TimeClaimVerifier.java
@@ -1,0 +1,52 @@
+package de.adorsys.sdjwt;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import de.adorsys.sdjwt.exception.SdJwtVerificationException;
+
+import java.time.Instant;
+
+/**
+ * Module for checking the validity of JWT time claims
+ */
+public class TimeClaimVerifier {
+
+    /**
+     * Tolerance window to account for clock skew
+     */
+    private final int leewaySeconds;
+
+    public TimeClaimVerifier(int leewaySeconds) {
+        this.leewaySeconds = leewaySeconds;
+    }
+
+    /**
+     * Validates that JWT has not expired
+     * @param jwtPayload the JWT's payload
+     */
+    public void verifyExpClaim(JsonNode jwtPayload) throws SdJwtVerificationException {
+        long exp = SdJwtUtils.readTimeClaim(jwtPayload, "exp");
+
+        if ((currentTimestamp() - leewaySeconds) >= exp) {
+            throw new SdJwtVerificationException("JWT has expired");
+        }
+    }
+
+    /**
+     * Validates that JWT can yet be processed
+     * @param jwtPayload the JWT's payload
+     */
+    public void verifyNotBeforeClaim(JsonNode jwtPayload) throws SdJwtVerificationException {
+        long nbf = SdJwtUtils.readTimeClaim(jwtPayload, "nbf");
+
+        if ((currentTimestamp() + leewaySeconds) < nbf) {
+            throw new SdJwtVerificationException("JWT is not yet valid");
+        }
+    }
+
+    /**
+     * Returns current timestamp in seconds.
+     */
+    public long currentTimestamp() {
+        return Instant.now().getEpochSecond();
+    }
+}

--- a/src/main/java/de/adorsys/sdjwt/TimeClaimVerifier.java
+++ b/src/main/java/de/adorsys/sdjwt/TimeClaimVerifier.java
@@ -10,21 +10,29 @@ import java.time.Instant;
  */
 public class TimeClaimVerifier {
 
+    public static final String CLAIM_NAME_EXP = "exp";
+    public static final String CLAIM_NAME_NBF = "nbf";
+
     /**
      * Tolerance window to account for clock skew
      */
     private final int leewaySeconds;
 
     public TimeClaimVerifier(int leewaySeconds) {
+        if (leewaySeconds < 0) {
+            throw new IllegalArgumentException("Leeway seconds cannot be negative");
+        }
+
         this.leewaySeconds = leewaySeconds;
     }
 
     /**
      * Validates that JWT has not expired
+     *
      * @param jwtPayload the JWT's payload
      */
     public void verifyExpClaim(JsonNode jwtPayload) throws SdJwtVerificationException {
-        long exp = SdJwtUtils.readTimeClaim(jwtPayload, "exp");
+        long exp = SdJwtUtils.readTimeClaim(jwtPayload, CLAIM_NAME_EXP);
 
         if ((currentTimestamp() - leewaySeconds) >= exp) {
             throw new SdJwtVerificationException("JWT has expired");
@@ -33,10 +41,11 @@ public class TimeClaimVerifier {
 
     /**
      * Validates that JWT can yet be processed
+     *
      * @param jwtPayload the JWT's payload
      */
     public void verifyNotBeforeClaim(JsonNode jwtPayload) throws SdJwtVerificationException {
-        long nbf = SdJwtUtils.readTimeClaim(jwtPayload, "nbf");
+        long nbf = SdJwtUtils.readTimeClaim(jwtPayload, CLAIM_NAME_NBF);
 
         if ((currentTimestamp() + leewaySeconds) < nbf) {
             throw new SdJwtVerificationException("JWT is not yet valid");

--- a/src/main/java/de/adorsys/sdjwt/vp/KeyBindingJwtVerificationOpts.java
+++ b/src/main/java/de/adorsys/sdjwt/vp/KeyBindingJwtVerificationOpts.java
@@ -22,19 +22,26 @@ public class KeyBindingJwtVerificationOpts {
     private final boolean validateExpirationClaim;
     private final boolean validateNotBeforeClaim;
 
+    /**
+     * Tolerance window to account for clock skew when checking time claims
+     */
+    private final int leewaySeconds;
+
     public KeyBindingJwtVerificationOpts(
             boolean keyBindingRequired,
             int allowedMaxAge,
             String nonce,
             String aud,
             boolean validateExpirationClaim,
-            boolean validateNotBeforeClaim) {
+            boolean validateNotBeforeClaim,
+            int leewaySeconds) {
         this.keyBindingRequired = keyBindingRequired;
         this.allowedMaxAge = allowedMaxAge;
         this.nonce = nonce;
         this.aud = aud;
         this.validateExpirationClaim = validateExpirationClaim;
         this.validateNotBeforeClaim = validateNotBeforeClaim;
+        this.leewaySeconds = leewaySeconds;
     }
 
     public boolean isKeyBindingRequired() {
@@ -61,6 +68,10 @@ public class KeyBindingJwtVerificationOpts {
         return validateNotBeforeClaim;
     }
 
+    public int getLeewaySeconds() {
+        return leewaySeconds;
+    }
+
     public static KeyBindingJwtVerificationOpts.Builder builder() {
         return new KeyBindingJwtVerificationOpts.Builder();
     }
@@ -72,6 +83,7 @@ public class KeyBindingJwtVerificationOpts {
         private String aud;
         private boolean validateExpirationClaim = true;
         private boolean validateNotBeforeClaim = true;
+        private int leewaySeconds = 10;
 
         public Builder withKeyBindingRequired(boolean keyBindingRequired) {
             this.keyBindingRequired = keyBindingRequired;
@@ -103,6 +115,11 @@ public class KeyBindingJwtVerificationOpts {
             return this;
         }
 
+        public Builder withLeewaySeconds(int leewaySeconds) {
+            this.leewaySeconds = leewaySeconds;
+            return this;
+        }
+
         public KeyBindingJwtVerificationOpts build() {
             if (keyBindingRequired && (aud == null || nonce == null || nonce.isEmpty())) {
                 throw new IllegalArgumentException(
@@ -116,7 +133,8 @@ public class KeyBindingJwtVerificationOpts {
                     nonce,
                     aud,
                     validateExpirationClaim,
-                    validateNotBeforeClaim
+                    validateNotBeforeClaim,
+                    leewaySeconds
             );
         }
     }

--- a/src/main/java/de/adorsys/sdjwt/vp/KeyBindingJwtVerificationOpts.java
+++ b/src/main/java/de/adorsys/sdjwt/vp/KeyBindingJwtVerificationOpts.java
@@ -1,11 +1,16 @@
 package de.adorsys.sdjwt.vp;
 
+import de.adorsys.sdjwt.TimeClaimVerificationOpts;
+
 /**
  * Options for Key Binding JWT verification.
  *
  * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
  */
-public class KeyBindingJwtVerificationOpts {
+public class KeyBindingJwtVerificationOpts extends TimeClaimVerificationOpts {
+
+    public static final int DEFAULT_ALLOWED_MAX_AGE = 5 * 60;
+
     /**
      * Specifies the Verify's policy whether to check Key Binding
      */
@@ -19,14 +24,6 @@ public class KeyBindingJwtVerificationOpts {
     private final String nonce;
     private final String aud;
 
-    private final boolean validateExpirationClaim;
-    private final boolean validateNotBeforeClaim;
-
-    /**
-     * Tolerance window to account for clock skew when checking time claims
-     */
-    private final int leewaySeconds;
-
     public KeyBindingJwtVerificationOpts(
             boolean keyBindingRequired,
             int allowedMaxAge,
@@ -35,13 +32,11 @@ public class KeyBindingJwtVerificationOpts {
             boolean validateExpirationClaim,
             boolean validateNotBeforeClaim,
             int leewaySeconds) {
+        super(validateExpirationClaim, validateNotBeforeClaim, leewaySeconds);
         this.keyBindingRequired = keyBindingRequired;
         this.allowedMaxAge = allowedMaxAge;
         this.nonce = nonce;
         this.aud = aud;
-        this.validateExpirationClaim = validateExpirationClaim;
-        this.validateNotBeforeClaim = validateNotBeforeClaim;
-        this.leewaySeconds = leewaySeconds;
     }
 
     public boolean isKeyBindingRequired() {
@@ -60,30 +55,15 @@ public class KeyBindingJwtVerificationOpts {
         return aud;
     }
 
-    public boolean mustValidateExpirationClaim() {
-        return validateExpirationClaim;
+    public static Builder builder() {
+        return new Builder();
     }
 
-    public boolean mustValidateNotBeforeClaim() {
-        return validateNotBeforeClaim;
-    }
-
-    public int getLeewaySeconds() {
-        return leewaySeconds;
-    }
-
-    public static KeyBindingJwtVerificationOpts.Builder builder() {
-        return new KeyBindingJwtVerificationOpts.Builder();
-    }
-
-    public static class Builder {
+    public static class Builder extends TimeClaimVerificationOpts.Builder<Builder> {
         private boolean keyBindingRequired = true;
-        private int allowedMaxAge = 5 * 60;
+        private int allowedMaxAge = DEFAULT_ALLOWED_MAX_AGE;
         private String nonce;
         private String aud;
-        private boolean validateExpirationClaim = true;
-        private boolean validateNotBeforeClaim = true;
-        private int leewaySeconds = 10;
 
         public Builder withKeyBindingRequired(boolean keyBindingRequired) {
             this.keyBindingRequired = keyBindingRequired;
@@ -102,21 +82,6 @@ public class KeyBindingJwtVerificationOpts {
 
         public Builder withAud(String aud) {
             this.aud = aud;
-            return this;
-        }
-
-        public Builder withValidateExpirationClaim(boolean validateExpirationClaim) {
-            this.validateExpirationClaim = validateExpirationClaim;
-            return this;
-        }
-
-        public Builder withValidateNotBeforeClaim(boolean validateNotBeforeClaim) {
-            this.validateNotBeforeClaim = validateNotBeforeClaim;
-            return this;
-        }
-
-        public Builder withLeewaySeconds(int leewaySeconds) {
-            this.leewaySeconds = leewaySeconds;
             return this;
         }
 

--- a/src/test/java/de/adorsys/sdjwt/SdJwsTest.java
+++ b/src/test/java/de/adorsys/sdjwt/SdJwsTest.java
@@ -44,42 +44,6 @@ public class SdJwsTest {
     }
 
     @Test
-    public void testVerifyExpClaim_ExpiredJWT() {
-        JsonNode payload = createPayload();
-        ((ObjectNode) payload).put("exp", Instant.now().minus(1, TimeUnit.HOURS.toChronoUnit()).getEpochSecond());
-        SdJws sdJws = new SdJws(payload) {
-        };
-        assertThrows(SdJwtVerificationException.class, sdJws::verifyExpClaim);
-    }
-
-    @Test
-    public void testVerifyExpClaim_Positive() throws Exception {
-        JsonNode payload = createPayload();
-        ((ObjectNode) payload).put("exp", Instant.now().plus(1, TimeUnit.HOURS.toChronoUnit()).getEpochSecond());
-        SdJws sdJws = new SdJws(payload) {
-        };
-        sdJws.verifyExpClaim();
-    }
-
-    @Test
-    public void testVerifyNotBeforeClaim_Negative() {
-        JsonNode payload = createPayload();
-        ((ObjectNode) payload).put("nbf", Instant.now().plus(1, TimeUnit.HOURS.toChronoUnit()).getEpochSecond());
-        SdJws sdJws = new SdJws(payload) {
-        };
-        assertThrows(SdJwtVerificationException.class, sdJws::verifyNotBeforeClaim);
-    }
-
-    @Test
-    public void testVerifyNotBeforeClaim_Positive() throws Exception {
-        JsonNode payload = createPayload();
-        ((ObjectNode) payload).put("nbf", Instant.now().minus(1, TimeUnit.HOURS.toChronoUnit()).getEpochSecond());
-        SdJws sdJws = new SdJws(payload) {
-        };
-        sdJws.verifyNotBeforeClaim();
-    }
-
-    @Test
     public void testPayloadJwsConstruction() {
         SdJws sdJws = new SdJws(createPayload()) {
         };

--- a/src/test/java/de/adorsys/sdjwt/SdJwtVerificationTest.java
+++ b/src/test/java/de/adorsys/sdjwt/SdJwtVerificationTest.java
@@ -155,35 +155,6 @@ public class SdJwtVerificationTest {
     }
 
     @Test
-    public void sdJwtVerificationShouldFail_IfIssuedInTheFuture() {
-        long now = Instant.now().getEpochSecond();
-
-        ObjectNode claimSet = mapper.createObjectNode();
-        claimSet.put("given_name", "John");
-        claimSet.put("iat", now + 1000); // issued in the future
-
-        // Exp claim is plain
-        var sdJwtV1 = exampleFlatSdJwtV2(claimSet, DisclosureSpec.builder().build()).build();
-        // Exp claim is undisclosed
-        var sdJwtV2 = exampleFlatSdJwtV2(claimSet, DisclosureSpec.builder()
-                .withRedListedClaimNames(DisclosureRedList.of(Set.of()))
-                .withUndisclosedClaim("iat", "eluV5Og3gSNII8EYnsxA_A")
-                .build()).build();
-
-        for (SdJwt sdJwt : List.of(sdJwtV1, sdJwtV2)) {
-            var exception = assertThrows(
-                    SdJwtVerificationException.class,
-                    () -> sdJwt.verify(defaultIssuerSignedJwtVerificationOpts()
-                            .withValidateIssuedAtClaim(true)
-                            .build())
-            );
-
-            assertEquals("Issuer-Signed JWT: Invalid `iat` claim", exception.getMessage());
-            assertEquals("JWT issued in the future", exception.getCause().getMessage());
-        }
-    }
-
-    @Test
     public void sdJwtVerificationShouldFail__IfNbfInvalid() {
         long now = Instant.now().getEpochSecond();
 
@@ -270,7 +241,6 @@ public class SdJwtVerificationTest {
     private IssuerSignedJwtVerificationOpts.Builder defaultIssuerSignedJwtVerificationOpts() {
         return IssuerSignedJwtVerificationOpts.builder()
                 .withVerifier(testSettings.issuerVerifierContext.verifier)
-                .withValidateIssuedAtClaim(false)
                 .withValidateExpirationClaim(false)
                 .withValidateNotBeforeClaim(false);
     }

--- a/src/test/java/de/adorsys/sdjwt/TimeClaimVerifierTest.java
+++ b/src/test/java/de/adorsys/sdjwt/TimeClaimVerifierTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.adorsys.sdjwt.exception.SdJwtVerificationException;
 import org.junit.Test;
 
+import static de.adorsys.sdjwt.TimeClaimVerifier.CLAIM_NAME_EXP;
+import static de.adorsys.sdjwt.TimeClaimVerifier.CLAIM_NAME_NBF;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -29,7 +31,7 @@ public class TimeClaimVerifierTest {
     @Test
     public void testVerifyExpClaimExpired() {
         ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
-        payload.put("exp", CURRENT_TIMESTAMP - 100); // Expired 100 seconds ago
+        payload.put(CLAIM_NAME_EXP, CURRENT_TIMESTAMP - 100); // Expired 100 seconds ago
 
         var exception = assertThrows(SdJwtVerificationException.class,
                 () -> timeClaimVerifier.verifyExpClaim(payload));
@@ -40,7 +42,7 @@ public class TimeClaimVerifierTest {
     @Test
     public void testVerifyExpClaimValid() throws SdJwtVerificationException {
         ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
-        payload.put("exp", CURRENT_TIMESTAMP + 100); // Expires 100 seconds in the future
+        payload.put(CLAIM_NAME_EXP, CURRENT_TIMESTAMP + 100); // Expires 100 seconds in the future
 
         timeClaimVerifier.verifyExpClaim(payload);
     }
@@ -48,7 +50,7 @@ public class TimeClaimVerifierTest {
     @Test
     public void testVerifyExpClaimEdge() throws SdJwtVerificationException {
         ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
-        payload.put("exp", CURRENT_TIMESTAMP - 59); // 59 seconds ago, within the 60 second leeway
+        payload.put(CLAIM_NAME_EXP, CURRENT_TIMESTAMP - 59); // 59 seconds ago, within the 60 second leeway
 
         // No exception expected for JWT expiring within leeway
         timeClaimVerifier.verifyExpClaim(payload);
@@ -57,7 +59,7 @@ public class TimeClaimVerifierTest {
     @Test
     public void testVerifyNotBeforeClaimNotYetValid() {
         ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
-        payload.put("nbf", CURRENT_TIMESTAMP + 100); // Not valid for another 100 seconds
+        payload.put(CLAIM_NAME_NBF, CURRENT_TIMESTAMP + 100); // Not valid for another 100 seconds
 
         var exception = assertThrows(SdJwtVerificationException.class,
                 () -> timeClaimVerifier.verifyNotBeforeClaim(payload));
@@ -68,7 +70,7 @@ public class TimeClaimVerifierTest {
     @Test
     public void testVerifyNotBeforeClaimValid() throws SdJwtVerificationException {
         ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
-        payload.put("nbf", CURRENT_TIMESTAMP - 100); // Valid since 100 seconds ago
+        payload.put(CLAIM_NAME_NBF, CURRENT_TIMESTAMP - 100); // Valid since 100 seconds ago
 
         timeClaimVerifier.verifyNotBeforeClaim(payload);
     }
@@ -77,9 +79,17 @@ public class TimeClaimVerifierTest {
     @Test
     public void testVerifyNotBeforeClaimEdge() throws SdJwtVerificationException {
         ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
-        payload.put("nbf", CURRENT_TIMESTAMP + 59); // 59 seconds in the future, within the 60 second leeway
+        payload.put(CLAIM_NAME_NBF, CURRENT_TIMESTAMP + 59); // 59 seconds in the future, within the 60 second leeway
 
         // No exception expected for JWT becoming valid within leeway
         timeClaimVerifier.verifyNotBeforeClaim(payload);
+    }
+
+    @Test
+    public void instantiationShouldFailIfLeewayNegative() {
+        var exception = assertThrows(IllegalArgumentException.class,
+                () -> new TimeClaimVerifier(-1));
+
+        assertEquals("Leeway seconds cannot be negative", exception.getMessage());
     }
 }

--- a/src/test/java/de/adorsys/sdjwt/TimeClaimVerifierTest.java
+++ b/src/test/java/de/adorsys/sdjwt/TimeClaimVerifierTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.adorsys.sdjwt.exception.SdJwtVerificationException;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 public class TimeClaimVerifierTest {
@@ -30,7 +31,10 @@ public class TimeClaimVerifierTest {
         ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
         payload.put("exp", CURRENT_TIMESTAMP - 100); // Expired 100 seconds ago
 
-        assertThrows(SdJwtVerificationException.class, () -> timeClaimVerifier.verifyExpClaim(payload));
+        var exception = assertThrows(SdJwtVerificationException.class,
+                () -> timeClaimVerifier.verifyExpClaim(payload));
+
+        assertEquals("JWT has expired", exception.getMessage());
     }
 
     @Test
@@ -55,7 +59,10 @@ public class TimeClaimVerifierTest {
         ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
         payload.put("nbf", CURRENT_TIMESTAMP + 100); // Not valid for another 100 seconds
 
-        assertThrows(SdJwtVerificationException.class, () -> timeClaimVerifier.verifyNotBeforeClaim(payload));
+        var exception = assertThrows(SdJwtVerificationException.class,
+                () -> timeClaimVerifier.verifyNotBeforeClaim(payload));
+
+        assertEquals("JWT is not yet valid", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/de/adorsys/sdjwt/TimeClaimVerifierTest.java
+++ b/src/test/java/de/adorsys/sdjwt/TimeClaimVerifierTest.java
@@ -1,0 +1,78 @@
+package de.adorsys.sdjwt;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.adorsys.sdjwt.exception.SdJwtVerificationException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+public class TimeClaimVerifierTest {
+
+    // 60 seconds of leeway
+    private final TimeClaimVerifier timeClaimVerifier = new FixedTimeClaimVerifier(60);
+
+    private static final long CURRENT_TIMESTAMP = 1609459200L; // Fixed timestamp: 2021-01-01 00:00:00 UTC
+
+    static class FixedTimeClaimVerifier extends TimeClaimVerifier {
+
+        public FixedTimeClaimVerifier(int leewaySeconds) {
+            super(leewaySeconds);
+        }
+
+        @Override
+        public long currentTimestamp() {
+            return CURRENT_TIMESTAMP;
+        }
+    }
+
+    @Test
+    public void testVerifyExpClaimExpired() {
+        ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
+        payload.put("exp", CURRENT_TIMESTAMP - 100); // Expired 100 seconds ago
+
+        assertThrows(SdJwtVerificationException.class, () -> timeClaimVerifier.verifyExpClaim(payload));
+    }
+
+    @Test
+    public void testVerifyExpClaimValid() throws SdJwtVerificationException {
+        ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
+        payload.put("exp", CURRENT_TIMESTAMP + 100); // Expires 100 seconds in the future
+
+        timeClaimVerifier.verifyExpClaim(payload);
+    }
+
+    @Test
+    public void testVerifyExpClaimEdge() throws SdJwtVerificationException {
+        ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
+        payload.put("exp", CURRENT_TIMESTAMP - 59); // 59 seconds ago, within the 60 second leeway
+
+        // No exception expected for JWT expiring within leeway
+        timeClaimVerifier.verifyExpClaim(payload);
+    }
+
+    @Test
+    public void testVerifyNotBeforeClaimNotYetValid() {
+        ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
+        payload.put("nbf", CURRENT_TIMESTAMP + 100); // Not valid for another 100 seconds
+
+        assertThrows(SdJwtVerificationException.class, () -> timeClaimVerifier.verifyNotBeforeClaim(payload));
+    }
+
+    @Test
+    public void testVerifyNotBeforeClaimValid() throws SdJwtVerificationException {
+        ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
+        payload.put("nbf", CURRENT_TIMESTAMP - 100); // Valid since 100 seconds ago
+
+        timeClaimVerifier.verifyNotBeforeClaim(payload);
+    }
+
+    // Test for verifyNotBeforeClaim (edge case: valid exactly at current time with leeway)
+    @Test
+    public void testVerifyNotBeforeClaimEdge() throws SdJwtVerificationException {
+        ObjectNode payload = SdJwtUtils.mapper.createObjectNode();
+        payload.put("nbf", CURRENT_TIMESTAMP + 59); // 59 seconds in the future, within the 60 second leeway
+
+        // No exception expected for JWT becoming valid within leeway
+        timeClaimVerifier.verifyNotBeforeClaim(payload);
+    }
+}

--- a/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
+++ b/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
@@ -234,7 +234,7 @@ public class SdJwtVPVerificationTest {
                         .withValidateExpirationClaim(true)
                         .build(),
                 "Key binding JWT: Invalid `exp` claim",
-                "jwt has expired"
+                "JWT has expired"
         );
     }
 
@@ -251,7 +251,7 @@ public class SdJwtVPVerificationTest {
                         .withValidateNotBeforeClaim(true)
                         .build(),
                 "Key binding JWT: Invalid `nbf` claim",
-                "jwt not valid yet"
+                "JWT is not yet valid"
         );
     }
 
@@ -365,7 +365,6 @@ public class SdJwtVPVerificationTest {
     private IssuerSignedJwtVerificationOpts.Builder defaultIssuerSignedJwtVerificationOpts() {
         return IssuerSignedJwtVerificationOpts.builder()
                 .withVerifier(testSettings.issuerVerifierContext.verifier)
-                .withValidateIssuedAtClaim(false)
                 .withValidateNotBeforeClaim(false);
     }
 

--- a/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
+++ b/src/test/java/de/adorsys/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
@@ -1,6 +1,10 @@
-
 package de.adorsys.sdjwt.sdjwtvp;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSSigner;
 import de.adorsys.sdjwt.IssuerSignedJwtVerificationOpts;
 import de.adorsys.sdjwt.SdJwt;
 import de.adorsys.sdjwt.TestSettings;
@@ -9,11 +13,6 @@ import de.adorsys.sdjwt.exception.SdJwtVerificationException;
 import de.adorsys.sdjwt.vp.KeyBindingJWT;
 import de.adorsys.sdjwt.vp.KeyBindingJwtVerificationOpts;
 import de.adorsys.sdjwt.vp.SdJwtVP;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSSigner;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -239,6 +238,25 @@ public class SdJwtVPVerificationTest {
     }
 
     @Test
+    public void shouldTolerateExpiredKbWithinLeeway() throws SdJwtVerificationException {
+        long now = Instant.now().getEpochSecond();
+
+        var kbPayload = exampleS20KbPayload();
+        // Expires just 5 seconds ago. Should pass with a leeway of 10 seconds.
+        kbPayload.set("exp", mapper.valueToTree(now - 5));
+
+        SdJwtVP sdJwtVP = exampleSdJwtWithCustomKbPayload(kbPayload);
+
+        sdJwtVP.verify(
+                defaultIssuerSignedJwtVerificationOpts().build(),
+                defaultKeyBindingJwtVerificationOpts()
+                        .withValidateExpirationClaim(true)
+                        .withLeewaySeconds(10)
+                        .build()
+        );
+    }
+
+    @Test
     public void testShouldFail_IfKbNotBeforeTimeYet() {
         long now = Instant.now().getEpochSecond();
 
@@ -252,6 +270,25 @@ public class SdJwtVPVerificationTest {
                         .build(),
                 "Key binding JWT: Invalid `nbf` claim",
                 "JWT is not yet valid"
+        );
+    }
+
+    @Test
+    public void shouldTolerateNotYetValidKbWithinLeeway() throws SdJwtVerificationException {
+        long now = Instant.now().getEpochSecond();
+
+        var kbPayload = exampleS20KbPayload();
+        // Will normally be valid in just 5 seconds ago. Should pass with a leeway of 10 seconds.
+        kbPayload.set("nbf", mapper.valueToTree(now + 5));
+
+        SdJwtVP sdJwtVP = exampleSdJwtWithCustomKbPayload(kbPayload);
+
+        sdJwtVP.verify(
+                defaultIssuerSignedJwtVerificationOpts().build(),
+                defaultKeyBindingJwtVerificationOpts()
+                        .withValidateNotBeforeClaim(true)
+                        .withLeewaySeconds(10)
+                        .build()
         );
     }
 
@@ -334,19 +371,7 @@ public class SdJwtVPVerificationTest {
             String exceptionMessage,
             String exceptionCauseMessage
     ) {
-        KeyBindingJWT keyBindingJWT = KeyBindingJWT.from(
-                kbPayloadSubstitute,
-                testSettings.holderSigContext.signer,
-                "holder",
-                JWSAlgorithm.ES256,
-                KeyBindingJWT.TYP
-        );
-
-        String sdJwtVPString = TestUtils.readFileAsString(getClass(), "sdjwt/s20.1-sdjwt+kb.txt");
-        SdJwtVP sdJwtVP = SdJwtVP.of(
-                sdJwtVPString.substring(0, sdJwtVPString.lastIndexOf(SdJwt.DELIMITER) + 1)
-                + keyBindingJWT.toJws()
-        );
+        SdJwtVP sdJwtVP = exampleSdJwtWithCustomKbPayload(kbPayloadSubstitute);
 
         var exception = assertThrows(
                 SdJwtVerificationException.class,
@@ -376,6 +401,21 @@ public class SdJwtVPVerificationTest {
                 .withAud("https://verifier.example.org")
                 .withValidateExpirationClaim(false)
                 .withValidateNotBeforeClaim(false);
+    }
+
+    private SdJwtVP exampleSdJwtWithCustomKbPayload(JsonNode kbPayloadSubstitute) {
+        KeyBindingJWT keyBindingJWT = KeyBindingJWT.from(
+                kbPayloadSubstitute,
+                testSettings.holderSigContext.signer,
+                "holder",
+                JWSAlgorithm.ES256,
+                KeyBindingJWT.TYP
+        );
+
+        String sdJwtVPString = TestUtils.readFileAsString(getClass(), "sdjwt/s20.1-sdjwt+kb.txt");
+        String sdJwtWithoutKb = sdJwtVPString.substring(0, sdJwtVPString.lastIndexOf(SdJwt.DELIMITER) + 1);
+
+        return SdJwtVP.of(sdJwtWithoutKb + keyBindingJWT.toJws());
     }
 
     private ObjectNode exampleS20KbPayload() {


### PR DESCRIPTION
Closes #20 

In a nutshell:
- Completely remove `iat` checks beyond emptying the corresponding method definition.
- Introduce a configurable leeway for `nbf` and `exp` checks.